### PR TITLE
update aframe-registry 0.5.0 ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/ngokevin/angle#readme",
   "dependencies": {
-    "aframe-registry": "^0.4.1",
+    "aframe-registry": "^0.5.0",
     "cheerio": "^0.22.0",
     "commander": "^2.9.0",
     "glob": "^7.1.1",


### PR DESCRIPTION
does angle version match aframe and aframe-registry?

for today 0.5.0 version
angle==aframe==aframe-registry ???

it would be better put version in one place or return last stable aframeVersion, than

```js
// var aframeVersion = Object.keys(require('aframe-registry')).sort().reverse()[0];
var aframeVersion = '0.5.0' || Object.keys(require('aframe-registry')).sort().reverse()[0];
```

aframe_version in https://github.com/aframevr/aframe-registry/blob/master/package.json#L4 ?

imho