### PR TITLE
Remove additional ../.. from dist on npm start dev

### DIFF
--- a/templates/component/package.json
+++ b/templates/component/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "cdn": "dist/{{ npmName }}.min.js",
   "scripts": {
-    "dev": "budo index.js:../../dist/{{ npmName }}.min.js --port 7000 --live --open",
+    "dev": "budo index.js:dist/{{ npmName }}.min.js --port 7000 --live --open",
     "dist": "webpack index.js dist/{{ npmName }}.js && webpack -p index.js dist/{{ npmName }}.min.js",
     "lint": "semistandard -v | snazzy",
     "prepublish": "npm run dist",


### PR DESCRIPTION
With the current path it keep giving me a 404 as the demo `index.html` is trying to reach `dist/component.js` but we're exposing `../../dist/componet.js` instead.