### PR TITLE
minor update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gh-pages
 node_modules/
 npm-debug.log
 .component
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 npm-debug.log
 .component
 package-lock.json
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 var program = require('commander');
 
+var version = require('./package.json').version;
+
 var initcomponent = require('./lib/initcomponent');
 var initscene = require('./lib/initscene');
 var install = require('./lib/install');
@@ -20,4 +22,6 @@ program
   .description('install component from registry to html file')
   .action(install);
 
-program.parse(process.argv);
+program
+  .version(version)
+  .parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -25,3 +25,5 @@ program
 program
   .version(version)
   .parse(process.argv);
+
+if (!program.args.length) program.help();

--- a/lib/initcomponent.js
+++ b/lib/initcomponent.js
@@ -15,7 +15,8 @@ function initcomponent () {
   console.log('Initializing A-Frame component...\n');
   mkdir('.component');
   // `cp -r`ing the whole directory has unexpected results. Doing a glob first.
-  glob.sync(path.resolve(__dirname, '../templates/component/*')).forEach(file => {
+  // `https://github.com/isaacs/node-glob#dots`
+  glob.sync(path.resolve(__dirname, '../templates/component/*'), {dot:true}).forEach(file => {
     cp('-r', file, './.component');
   });
   cd('./.component');

--- a/templates/component/.gitignore
+++ b/templates/component/.gitignore
@@ -5,3 +5,5 @@ gh-pages
 node_modules/
 npm-debug.log
 .component
+package-lock.json
+yarn.lock

--- a/templates/component/examples/basic/index.html
+++ b/templates/component/examples/basic/index.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>A-Frame {{ prettyName }} Component - Basic</title>
     <meta name="description" content="Basic example for {{ prettyName }} component."></meta>
     <script src="https://aframe.io/releases/{{ aframeVersion }}/aframe.min.js"></script>

--- a/templates/component/index.html
+++ b/templates/component/index.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>A-Frame {{ prettyName }} Component</title>
     <meta name="description" content="{{ description }}"></meta>
     <style>


### PR DESCRIPTION
fixed

* html example wo `DOCTYPE` and `charset`
* angle wo `version`
* show `help` if no args
* `package-lock.json` to `.gitignore` ( latest npm (node 8) has errors, so some developer useing `npmc`)