### PR TITLE
add crossorigin attributes to <img />s to suppress warnings

### DIFF
--- a/templates/component/examples/basic/index.html
+++ b/templates/component/examples/basic/index.html
@@ -10,8 +10,8 @@
   <body>
     <a-scene>
       <a-assets>
-        <img id="groundTexture" src="https://cdn.aframe.io/a-painter/images/floor.jpg">
-        <img id="skyTexture" src="https://cdn.aframe.io/a-painter/images/sky.jpg">
+        <img id="groundTexture" src="https://cdn.aframe.io/a-painter/images/floor.jpg" crossorigin="anonymous">
+        <img id="skyTexture" src="https://cdn.aframe.io/a-painter/images/sky.jpg" crossorigin="anonymous">
       </a-assets>
 
       <a-entity {{ shortName }}=""></a-entity>

--- a/templates/scene/index.html
+++ b/templates/scene/index.html
@@ -9,8 +9,8 @@
   <body>
     <a-scene>
       <a-assets>
-        <img id="groundTexture" src="https://cdn.aframe.io/a-painter/images/floor.jpg">
-        <img id="skyTexture" src="https://cdn.aframe.io/a-painter/images/sky.jpg">
+        <img id="groundTexture" src="https://cdn.aframe.io/a-painter/images/floor.jpg" crossorigin="anonymous">
+        <img id="skyTexture" src="https://cdn.aframe.io/a-painter/images/sky.jpg" crossorigin="anonymous">
       </a-assets>
 
       <!-- Primitives. -->


### PR DESCRIPTION
I was getting the following warning in console and this patch seems to have fixed it.

```
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">) 
```

![screen shot 2017-07-13 at 11 57 30](https://user-images.githubusercontent.com/601961/28163342-a711c348-67c2-11e7-9f79-1e26a2f9647a.png)
